### PR TITLE
Fix nav links and static routing on live site

### DIFF
--- a/fix_nav.sh
+++ b/fix_nav.sh
@@ -1,0 +1,1 @@
+sed -i 's|<li><a href="seniority-paradox.html">Blog</a></li>|<li><a href="about.htm">About</a></li>\n    <li><a href="seniority-paradox.html">Blog</a></li>|g' index.htm resume.html seniority-paradox.html

--- a/fix_nav.sh
+++ b/fix_nav.sh
@@ -1,1 +1,0 @@
-sed -i 's|<li><a href="seniority-paradox.html">Blog</a></li>|<li><a href="about.htm">About</a></li>\n    <li><a href="seniority-paradox.html">Blog</a></li>|g' index.htm resume.html seniority-paradox.html

--- a/index.htm
+++ b/index.htm
@@ -14,6 +14,15 @@
 <body>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
+<nav class="top-nav">
+  <ul>
+    <li><a href="index.htm">Home</a></li>
+    <li><a href="about.htm">About</a></li>
+    <li><a href="seniority-paradox.html">Blog</a></li>
+    <li><a href="resume.html">Resume</a></li>
+  </ul>
+</nav>
+
 <!-- ============================================================
      HERO
      ============================================================ -->

--- a/resume.html
+++ b/resume.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;1,8..60,300;1,8..60,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="./static/new.css">
   <style>
     :root {
       --bg: #ffffff;
@@ -257,6 +258,15 @@
   </style>
 </head>
 <body>
+
+<nav class="top-nav screen-only">
+  <ul>
+    <li><a href="index.htm">Home</a></li>
+    <li><a href="about.htm">About</a></li>
+    <li><a href="seniority-paradox.html">Blog</a></li>
+    <li><a href="resume.html">Resume</a></li>
+  </ul>
+</nav>
 
 <!-- ══════════════ HEADER ══════════════ -->
 <div class="resume-header">

--- a/seniority-paradox.html
+++ b/seniority-paradox.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>The Seniority Paradox | Brian W. Smith</title>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+<link href='https://fonts.googleapis.com/css?family=Abel' rel='stylesheet' type='text/css'>
+<link rel="stylesheet" type="text/css" href="./static/new.css">
+<style>
+  .blog-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 40px 20px;
+    color: var(--text);
+    font-family: var(--font-serif);
+    line-height: 1.6;
+  }
+  .blog-container h1 {
+    font-family: var(--font-display);
+    color: var(--accent);
+    font-size: 2.5em;
+    margin-bottom: 0.5em;
+  }
+  .blog-container h2 {
+    font-family: var(--font-display);
+    color: var(--accent);
+    font-size: 1.8em;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+  }
+  .blog-container h3 {
+    font-family: var(--font-mono);
+    color: var(--link);
+    font-size: 1.2em;
+    margin-top: 1.2em;
+    margin-bottom: 0.4em;
+  }
+  .blog-container p {
+    margin-bottom: 1em;
+    font-size: 1.1em;
+  }
+  .blog-container ul {
+    margin-bottom: 1em;
+    padding-left: 20px;
+  }
+  .blog-container li {
+    margin-bottom: 0.5em;
+    font-size: 1.1em;
+  }
+  .blog-container strong {
+    color: var(--accent);
+  }
+  .blog-container .intro-text {
+    font-size: 1.25em;
+    font-style: italic;
+    color: var(--muted);
+    border-left: 4px solid var(--accent);
+    padding-left: 15px;
+    margin-bottom: 2em;
+  }
+  .blog-container .discussion-prompt {
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    padding: 20px;
+    margin-top: 2em;
+    border-radius: 4px;
+  }
+  .blog-container table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+    background-color: var(--surface);
+  }
+  .blog-container th, .blog-container td {
+    border: 1px solid var(--border);
+    padding: 12px;
+    text-align: left;
+    font-size: 1.05em;
+  }
+  .blog-container th {
+    background-color: var(--border);
+    color: var(--accent);
+    font-family: var(--font-mono);
+  }
+</style>
+</head>
+<body>
+
+  <nav class="top-nav">
+    <ul>
+      <li><a href="index.htm">Home</a></li>
+      <li><a href="about.htm">About</a></li>
+    <li><a href="seniority-paradox.html">Blog</a></li>
+      <li><a href="resume.html">Resume</a></li>
+    </ul>
+  </nav>
+
+  <section class="blog-post">
+    <div class="blog-container">
+      <h1>The Seniority Paradox: Architecting a Path to Sustainable Peace</h1>
+
+      <div class="intro-text">
+        <p>This document explores the structural and psychological transitions often faced by deep-tenure professionals as they seek to align decades of experience with a sustainable, high-trust work environment.</p>
+      </div>
+
+      <h2>I. The Context: A Late-Career Paradox</h2>
+      <p>For professionals with over two decades of experience, a surprising paradox often emerges. While individual capability is at its historical peak—built on a foundation of "scar tissue" and high-level pattern recognition—there is often a mounting sense of exhaustion. This is rarely a reflection of a skill deficit; rather, it is a signal of a systemic mismatch between a veteran’s need for authenticity and a modern, high-velocity corporate culture.</p>
+
+      <h2>II. Challenges of the "Senior Tier"</h2>
+      <ul>
+        <li><strong>The Expertise Trap:</strong> An industry-wide expectation that seniors must "already have" every emerging skill. This creates a "double-processing" tax where veterans must calculate objective truths while simultaneously navigating the politics of delivering them.</li>
+        <li><strong>The Transparency Gap:</strong> Veterans often value radical honesty and "boring, stable solutions." In cultures obsessed with short-term metrics, this honesty can be misinterpreted as friction or a lack of "buy-in," leading to increased scrutiny.</li>
+        <li><strong>Cognitive Overload & "Safe Mode":</strong> When a work environment shifts from collaborative to hyper-critical, the brain triggers a protective shutdown. This isn't a loss of capability; it is a physiological response to an environment that has exhausted its organizational "Error Budget."</li>
+      </ul>
+
+      <h2>III. The Shift: From Performance to Systemic Impact</h2>
+      <p>To find sustainability in the later stages of a career, many are moving away from "performing expertise" and toward roles that prioritize systemic impact over interpersonal friction.</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>The Performance Phase</th>
+            <th>The Impact Phase</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Ownership of every "right" solution</td>
+            <td><strong>Intellectual Detachment:</strong> Providing expert advice as a service</td>
+          </tr>
+          <tr>
+            <td>Winning arguments to protect the project</td>
+            <td><strong>Strategic Alignment:</strong> Navigating systems rather than people</td>
+          </tr>
+          <tr>
+            <td>Constant availability and "Expert" posturing</td>
+            <td><strong>Conservation:</strong> Prioritizing output over corporate "presence"</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>IV. Identifying a "Safe Harbor"</h2>
+      <p>The goal for the senior professional is to identify organizations where being "radically honest" is viewed as a high-value asset for risk mitigation. Key indicators include:</p>
+      <ul>
+        <li><strong>Asynchronous Communication:</strong> Reducing "performance theater" and allowing for thoughtful, documented contributions.</li>
+        <li><strong>Psychological Safety:</strong> Cultures where "I don’t know yet" is viewed as an invitation to collaborate rather than a sign of weakness.</li>
+        <li><strong>Low-Ego Environments:</strong> Where the "boring, correct solution" is celebrated over the "heroic, fast hack."</li>
+      </ul>
+
+      <h2>V. Conclusion</h2>
+      <p>Professional skills are rarely "lost"; they are often simply "offline for repairs" due to environmental incompatibility. The most senior thing a professional can do is recognize when a system is no longer sustainable and architect a move toward a high-trust, low-fear environment.</p>
+
+      <div class="discussion-prompt">
+        <h3>Discussion Prompt</h3>
+        <p>As we reach the later stages of our careers, how do we move away from the 'Expert Performance' trap and toward a role that values our wisdom while protecting our peace?</p>
+      </div>
+
+    </div>
+  </section>
+
+</body>
+</html>

--- a/static/new.css
+++ b/static/new.css
@@ -771,3 +771,10 @@ label:hover { color: var(--muted); cursor: pointer; }
 .top-nav a:hover, .top-nav a.active {
   color: var(--accent);
 }
+
+
+@media print {
+  .screen-only {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
This PR corrects an issue where the new navigation menu and blog post were not visible on the live site because they were built as Flask templates instead of root static HTML files used by GitHub Pages.

Changes:
- Extracted the formatting for the "Seniority Paradox" blog post into a standalone `seniority-paradox.html` file in the root repo.
- Modified the root `index.htm` and `resume.html` files to contain the newly built top navigation menu using relative path links.
- Corrected a small oversight by adding the "About" link to the static file navigation menus.
- Added a simple print query to ensure the navigation bar on `resume.html` doesn't mess up print layouts.

---
*PR created automatically by Jules for task [8692834383414388946](https://jules.google.com/task/8692834383414388946) started by @theautoroboto*