### PR TITLE
Update resume with Immuta experience and fix chronological order

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -368,11 +368,35 @@
     </div>
   </div>
 
+  <!-- OneStream -->
+  <div class="job">
+    <div class="job-header">
+      <span class="job-company">OneStream Software</span>
+      <span class="job-dates">February 2021 — November 2021</span>
+    </div>
+    <div class="job-title">First DevOps Engineer</div>
+    <ul class="bullets">
+      <li>Migrated 70+ repositories from TFS to Azure DevOps; implemented SonarQube SAST scanning, GitFlow branch strategy, and Azure Pipelines CI/CD as the organization's founding DevOps engineer.</li>
+    </ul>
+  </div>
+
+  <!-- Immuta -->
+  <div class="job">
+    <div class="job-header">
+      <span class="job-company">Immuta</span>
+      <span class="job-dates">August 2020 — February 2021</span>
+    </div>
+    <div class="job-title">Cloud Engineer</div>
+    <ul class="bullets">
+      <li>Joined for the amazing culture and people. Brought my extensive infrastructure experience to the team.</li>
+    </ul>
+  </div>
+
   <!-- Fiserv -->
   <div class="job">
     <div class="job-header">
       <span class="job-company">Fiserv</span>
-      <span class="job-dates">March 2017 — November 2021</span>
+      <span class="job-dates">March 2017 — August 2020</span>
     </div>
     <div class="job-title">Senior System Engineer Lead — Cloud Platform</div>
     <ul class="bullets">
@@ -384,16 +408,6 @@
   </div>
 
   <!-- Earlier -->
-  <div class="job">
-    <div class="job-header">
-      <span class="job-company">OneStream Software</span>
-      <span class="job-dates">February 2021 — November 2021</span>
-    </div>
-    <div class="job-title">First DevOps Engineer</div>
-    <ul class="bullets">
-      <li>Migrated 70+ repositories from TFS to Azure DevOps; implemented SonarQube SAST scanning, GitFlow branch strategy, and Azure Pipelines CI/CD as the organization's founding DevOps engineer.</li>
-    </ul>
-  </div>
 
   <div class="job">
     <div class="job-header">

--- a/resume_posthog.html
+++ b/resume_posthog.html
@@ -352,11 +352,35 @@
     </div>
   </div>
 
+  <!-- OneStream -->
+  <div class="job">
+    <div class="job-header">
+      <span class="job-company">OneStream Software</span>
+      <span class="job-dates">February 2021 — November 2021</span>
+    </div>
+    <div class="job-title">First DevOps Engineer</div>
+    <ul class="bullets">
+      <li>Migrated 70+ repositories from TFS to Azure DevOps; implemented SonarQube SAST scanning, GitFlow branch strategy, and Azure Pipelines CI/CD as the organization's founding DevOps engineer.</li>
+    </ul>
+  </div>
+
+  <!-- Immuta -->
+  <div class="job">
+    <div class="job-header">
+      <span class="job-company">Immuta</span>
+      <span class="job-dates">August 2020 — February 2021</span>
+    </div>
+    <div class="job-title">Cloud Engineer</div>
+    <ul class="bullets">
+      <li>Joined for the amazing culture and people. Brought my extensive infrastructure experience to the team.</li>
+    </ul>
+  </div>
+
   <!-- Fiserv -->
   <div class="job">
     <div class="job-header">
       <span class="job-company">Fiserv</span>
-      <span class="job-dates">March 2017 — November 2021</span>
+      <span class="job-dates">March 2017 — August 2020</span>
     </div>
     <div class="job-title">Senior System Engineer Lead — Cloud Platform</div>
     <ul class="bullets">
@@ -368,16 +392,6 @@
   </div>
 
   <!-- Earlier -->
-  <div class="job">
-    <div class="job-header">
-      <span class="job-company">OneStream Software</span>
-      <span class="job-dates">February 2021 — November 2021</span>
-    </div>
-    <div class="job-title">First DevOps Engineer</div>
-    <ul class="bullets">
-      <li>Migrated 70+ repositories from TFS to Azure DevOps; implemented SonarQube SAST scanning, GitFlow branch strategy, and Azure Pipelines CI/CD as the organization's founding DevOps engineer.</li>
-    </ul>
-  </div>
 
   <div class="job">
     <div class="job-header">


### PR DESCRIPTION
- Added Immuta experience (August 2020 - February 2021) based on user input and `api/app.py` data.
- Reordered experience chronologically (Red Hat -> OneStream -> Immuta -> Fiserv -> Grange -> Earlier).
- Adjusted Fiserv dates to end in August 2020 to prevent overlap.
- Applied changes consistently to both `resume.html` and `resume_posthog.html`.
- Verified frontend updates locally.

---
*PR created automatically by Jules for task [16611665877841762312](https://jules.google.com/task/16611665877841762312) started by @theautoroboto*