### PR TITLE
🎨 Palette: Add ARIA labels to AskBrian chat input and button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-05 - AskBrian Chat Accessibility
+**Learning:** Found an icon-only send button and an unlabelled textarea input in the AskBrian chat interface. Added `aria-label` attributes to ensure screen readers announce them properly as "Your message" and "Send message".
+**Action:** When adding or maintaining chat interfaces, ensure all form elements and icon-only buttons have descriptive ARIA labels to maintain accessibility standards.

--- a/AskBrian/index.htm
+++ b/AskBrian/index.htm
@@ -42,11 +42,12 @@
         <div class="input-area">
             <textarea
                 id="user-input"
+                aria-label="Your message"
                 placeholder="Ask about Brian's experience, skills, or background..."
                 rows="1"
                 maxlength="500"
             ></textarea>
-            <button id="send-btn" onclick="sendMessage()">
+            <button id="send-btn" aria-label="Send message" onclick="sendMessage()">
                 <i class="fas fa-paper-plane"></i>
             </button>
         </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the textarea and send button in the AskBrian chat interface.
🎯 Why: To improve accessibility for screen reader users by providing descriptive text for an unlabelled input field and an icon-only button.
♿ Accessibility: Ensures the textarea is announced as "Your message" and the send button as "Send message".

---
*PR created automatically by Jules for task [9153975464358765524](https://jules.google.com/task/9153975464358765524) started by @theautoroboto*