### PR TITLE
Fix header in seniority-paradox.html

### DIFF
--- a/seniority-paradox.html
+++ b/seniority-paradox.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<title>The Seniority Paradox | Brian W. Smith</title>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-<link href='https://fonts.googleapis.com/css?family=Abel' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" type="text/css" href="./static/new.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Seniority Paradox | Brian W. Smith</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=JetBrains+Mono:wght@400;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;1,8..60,300;1,8..60,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" type="text/css" href="./static/new.css">
 <style>
   .blog-container {
     max-width: 800px;

--- a/verify.py
+++ b/verify.py
@@ -1,0 +1,21 @@
+import asyncio
+from playwright.async_api import async_playwright
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        # Navigate to the page
+        await page.goto("http://localhost:8000/seniority-paradox.html")
+
+        # Make sure the directory exists
+        os.makedirs("/home/jules/verification/screenshots", exist_ok=True)
+
+        # Take screenshot
+        await page.screenshot(path="/home/jules/verification/screenshots/seniority-paradox.png", full_page=True)
+
+        await browser.close()
+
+asyncio.run(main())


### PR DESCRIPTION
Updates the `<head>` section in `seniority-paradox.html` to align with the rest of the site. It replaces the legacy Abel font link with the standard `preconnect` and `stylesheet` links for `Abril Fatface`, `JetBrains Mono`, and `Source Serif 4` used by `new.css`. It also adds standard `viewport` and `charset` metadata tags, and the missing `lang="en"` attribute to the html tag.

---
*PR created automatically by Jules for task [10817033293628341978](https://jules.google.com/task/10817033293628341978) started by @theautoroboto*