### PR TITLE
Fix timeline loading delay and align bullets to top of cards

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -1,36 +1,25 @@
 (function() {
+  'use strict';
 
-    'use strict';
-  
-    // define variables
-    var items = document.querySelectorAll(".timeline li");
-  
-    // check if an element is in viewport
-    // http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport
-    function isElementInViewport(el) {
-      var rect = el.getBoundingClientRect();
-      return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-      );
-    }
-  
-    function callbackFunc() {
-      for (var i = 0; i < items.length; i++) {
-        if (isElementInViewport(items[i])) {
-          items[i].classList.add("in-view");
-        }
+  var items = document.querySelectorAll(".timeline li:not(.era-marker)");
+
+  var observer = new IntersectionObserver(function(entries, observer) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting || entry.boundingClientRect.top < 0) {
+        entry.target.classList.add("in-view");
+        observer.unobserve(entry.target);
       }
-    }
-  
-    // listen for events
-    window.addEventListener("load", callbackFunc);
-    window.addEventListener("resize", callbackFunc);
-    window.addEventListener("scroll", callbackFunc);
-  
-  })();
+    });
+  }, {
+    rootMargin: "0px 0px -5% 0px"
+  });
+
+  items.forEach(function(item) {
+    observer.observe(item);
+  });
+
+})();
+
 $(document).ready(function() {
   $('.image-link').magnificPopup({type:'image'});
 

--- a/static/new.css
+++ b/static/new.css
@@ -348,7 +348,7 @@ a:hover { color: var(--accent); }
   content: '';
   position: absolute;
   left: 50%;
-  bottom: 0;
+  top: 14px;
   transform: translateX(-50%);
   width: 12px;
   height: 12px;


### PR DESCRIPTION
Replaced the manual window scroll event checking the bottom of bounding client rect with an Intersection Observer to load timeline items as soon as they enter the screen. Adjusted the spine indicator in `static/new.css` from bottom to top alignment.

---
*PR created automatically by Jules for task [6950107130621297364](https://jules.google.com/task/6950107130621297364) started by @theautoroboto*