### PR TITLE
Update Immuta experience and remove earlier roles

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -420,7 +420,7 @@
     <li>
       <div class="milestone">
         <time>08/2020 — Joining Immuta</time>
-        <p>Throughout my career and with each job change, I search for a culture fit. The culture brought me to Immuta. Everyone I work with is absolutely amazing.</p>
+        <p>Working with customers to install and configure Immuta’s software. This requires in-depth knowledge of many data warehouse technologies such as Databricks, Athena, Snowflake, Redshift, among many others. My Kubernetes knowledge and long history working with various technologies has given me the ability to quickly learn these new technologies.</p>
       </div>
     </li>
     <li>

--- a/resume.html
+++ b/resume.html
@@ -388,7 +388,7 @@
     </div>
     <div class="job-title">Cloud Engineer</div>
     <ul class="bullets">
-      <li>Joined for the amazing culture and people. Brought my extensive infrastructure experience to the team.</li>
+      <li>Working with customers to install and configure Immuta’s software. This requires in-depth knowledge of many data warehouse technologies such as Databricks, Athena, Snowflake, Redshift, among many others. My Kubernetes knowledge and long history working with various technologies has given me the ability to quickly learn these new technologies.</li>
     </ul>
   </div>
 
@@ -407,30 +407,6 @@
     </ul>
   </div>
 
-  <!-- Earlier -->
-
-  <div class="job">
-    <div class="job-header">
-      <span class="job-company">Grange Insurance</span>
-      <span class="job-dates">2006 – 2017 (with gap 2008)</span>
-    </div>
-    <div class="job-title">Senior System Engineer — Exchange / Active Directory / Messaging</div>
-    <ul class="bullets">
-      <li>Migrated 3,000 on-premise Exchange 2013 mailboxes to O365; administered 9-server Exchange 2003/2007/2013 environment; architected AD, ADFS, PKI, KMS, PeopleSoft GL integrations, and enterprise FTP platform.</li>
-      <li>Built PowerShell and VB automation tooling including a New User Tool, nested AD group reporting, AD photo import pipeline, and SharePoint offboarding automation.</li>
-    </ul>
-  </div>
-
-  <div class="job">
-    <div class="job-header">
-      <span class="job-company">Earlier Roles</span>
-      <span class="job-dates">1998 – 2008</span>
-    </div>
-    <div class="job-title">NetJets (Sr. Network Admin) · BMW Financial (CRM Admin) · Cardinal Health (Sr. Messaging Engineer) · WD Partners (IT Admin)</div>
-    <ul class="bullets">
-      <li>25+ years of progressive infrastructure experience spanning messaging, networking, virtualisation, enterprise AD/Exchange, and automation — from first ISP support role (BellSouth.net) through senior engineering leadership.</li>
-    </ul>
-  </div>
 </div>
 
 <!-- ══════════════ BOTTOM TWO-COL ══════════════ -->

--- a/templates/index.htm
+++ b/templates/index.htm
@@ -110,7 +110,7 @@
       <li>
         <div>
           <time>Joining Immuta - 08/20</time>
-          <p>Throughout my career and with each job change, I search for a culture fit. The culture brought me to Immuta. Everyone I work with is absolutely AMAZING</p>
+          <p>Working with customers to install and configure Immuta’s software. This requires in-depth knowledge of many data warehouse technologies such as Databricks, Athena, Snowflake, Redshift, among many others. My Kubernetes knowledge and long history working with various technologies has given me the ability to quickly learn these new technologies.</p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
Update Immuta experience and remove earlier roles

Replaced the Immuta job description in `resume.html`, `index.htm`, and `templates/index.htm` with the newly provided text detailing experience with various data warehouse technologies and Kubernetes. Also removed roles earlier than Fiserv from `resume.html` to make Fiserv the oldest employment on the resume.

---
*PR created automatically by Jules for task [4242737177567768384](https://jules.google.com/task/4242737177567768384) started by @theautoroboto*