### PR TITLE
Fix resume header formatting caused by non-breaking spaces in title-line

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -100,9 +100,13 @@
         font-size: 8pt;
         color: var(--muted);
         display: flex;
-        gap: 18px;
+        gap: 12px 20px;
         flex-wrap: wrap;
+        align-items: center;
       }
+
+      .contact-row a,
+      .contact-row span { white-space: nowrap; }
 
       .contact-row a { color: var(--accent); }
 
@@ -384,7 +388,7 @@
 <div class="resume-header">
   <div class="header-left">
     <div class="name">Brian W. Smith</div>
-    <div class="title-line">Principal Site Reliability Engineer &nbsp;·&nbsp; Engineering Excellence &nbsp;·&nbsp; Reliability Frameworks &nbsp;·&nbsp; Observability at Scale</div>
+    <div class="title-line">Principal Site Reliability Engineer · Engineering Excellence · Reliability Frameworks · Observability at Scale</div>
     <div class="contact-row">
       <span>Columbus, OH</span>
       <a href="https://theautoroboto.github.io">theautoroboto.github.io</a>


### PR DESCRIPTION
The &nbsp;·&nbsp; entities made the title an unbreakable ~900px string,
forcing the CSS Grid 1fr column wider than the available space and causing
contact-row items to each stack on their own line. Replaced with regular
spaces so the title wraps naturally at the dot separators. Also added
white-space: nowrap to contact items so they break between items, not
mid-URL, and tightened the row gap.

https://claude.ai/code/session_01AehstTpttJovfMyNzwtsnw