### PR TITLE
Replace vague SLO/SLI stat with concrete 800+ NIST controls metric

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -412,12 +412,12 @@
     <span class="stat-lbl">Kubernetes Clusters at Scale</span>
   </div>
   <div class="stat-item">
-    <span class="stat-num">SLO</span>
-    <span class="stat-lbl">SLI / Error Budget Frameworks</span>
+    <span class="stat-num">800+</span>
+    <span class="stat-lbl">NIST 800-53 Controls Automated</span>
   </div>
   <div class="stat-item">
     <span class="stat-num">7,000+</span>
-    <span class="stat-lbl">7,000+ Microservices — Fiserv PCF Platform</span>
+    <span class="stat-lbl">Microservices — Fiserv PCF Platform</span>
   </div>
 </div>
 


### PR DESCRIPTION
Swapped out the non-quantitative "SLO / SLI / Error Budget Frameworks"
stat (which read as an acronym, not a metric) for "800+ / NIST 800-53
Controls Automated" — a concrete, distinctive achievement from the
FedRAMP AI pipeline work. Also removed the redundant "7,000+" prefix
from the Fiserv microservices label.

https://claude.ai/code/session_0196zJnfNic8MNVAejcM2WQp