### PR TITLE
🧹 Remove unused `formatter` variable from AutoLotto script

### DIFF
--- a/AutoLotto/script.js
+++ b/AutoLotto/script.js
@@ -16,12 +16,6 @@ const times_played = document.getElementById('times_played');
 const num_correct = document.getElementById('correct');
 const auto_btn = document.getElementById('autoPick');
 
-const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2
-  })
-
 winnings.textContent = 0;
 times_played.textContent = 0;
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `formatter` variable from `AutoLotto/script.js`.
💡 **Why:** This variable was declared and initialized but never used elsewhere in the code. Removing dead code reduces file size, reduces cognitive load, and improves maintainability.
✅ **Verification:** A Playwright script was used to interact with the frontend components, proving the site continues to function correctly without this variable.
✨ **Result:** A cleaner codebase with less unused code and no change to application behavior.

---
*PR created automatically by Jules for task [6972904439002136447](https://jules.google.com/task/6972904439002136447) started by @theautoroboto*