### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -17,7 +17,7 @@ from flask import Flask, Response, request, stream_with_context
 from flask_cors import CORS
 
 app = Flask(__name__)
-CORS(app)
+CORS(app, origins=["https://theautoroboto.github.io", "http://localhost:5001", "http://127.0.0.1:5001"])
 
 # ---------------------------------------------------------------------------
 # Ask Brian — system prompt with full career context (prompt-cached)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `api/app.py` service utilized a blanket `CORS(app)` configuration, which resulted in an overly permissive CORS policy that blindly accepted cross-origin requests from any domain.

⚠️ **Risk:** The potential impact if left unfixed
An overly permissive CORS configuration allowed any website on the internet to make cross-origin requests to this application's API endpoints (`/api/ask`, `/api/fedramp`). This could have been exploited by attackers to exhaust API quotas or conduct Cross-Site Request Forgery (CSRF) if the API later implemented authenticated interactions.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the default `CORS(app)` statement with an explicit `origins` allowlist constraint in `api/app.py`, specifically allowing requests only from `https://theautoroboto.github.io`, `http://localhost:5001`, and `http://127.0.0.1:5001`. Unauthorized origins are now successfully blocked by the server and will not receive `Access-Control-Allow-Origin` headers.

---
*PR created automatically by Jules for task [9000771861975165758](https://jules.google.com/task/9000771861975165758) started by @theautoroboto*