### PR TITLE
🎨 Palette: activate nav current-page indicator on all pages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-06 - Nav active state: CSS defined but never applied
+Learning: This site had `.top-nav a.active { color: var(--accent); }` in the stylesheet from the start, but no page ever set `class="active"` on its own nav link. The ghost rule was invisible until inspected. Pattern to watch for: orphaned CSS active/current selectors that look intentional but were never wired up.
+Action: On any multi-page static site, always verify that nav active-state CSS is actually applied via `class="active"` + `aria-current="page"` on each page's own link — not just present in the stylesheet.

--- a/about.htm
+++ b/about.htm
@@ -54,7 +54,7 @@
 <nav class="top-nav">
   <ul>
     <li><a href="index.htm">Home</a></li>
-    <li><a href="about.htm">About</a></li>
+    <li><a href="about.htm" class="active" aria-current="page">About</a></li>
     <li><a href="seniority-paradox.html">Blog</a></li>
     <li><a href="resume.html">Resume</a></li>
   </ul>

--- a/index.htm
+++ b/index.htm
@@ -16,7 +16,7 @@
 
 <nav class="top-nav">
   <ul>
-    <li><a href="index.htm">Home</a></li>
+    <li><a href="index.htm" class="active" aria-current="page">Home</a></li>
     <li><a href="about.htm">About</a></li>
     <li><a href="seniority-paradox.html">Blog</a></li>
     <li><a href="resume.html">Resume</a></li>

--- a/resume.html
+++ b/resume.html
@@ -378,7 +378,7 @@
     <li><a href="index.htm">Home</a></li>
     <li><a href="about.htm">About</a></li>
     <li><a href="seniority-paradox.html">Blog</a></li>
-    <li><a href="resume.html">Resume</a></li>
+    <li><a href="resume.html" class="active" aria-current="page">Resume</a></li>
   </ul>
 </nav>
 

--- a/seniority-paradox.html
+++ b/seniority-paradox.html
@@ -94,7 +94,7 @@
     <ul>
       <li><a href="index.htm">Home</a></li>
       <li><a href="about.htm">About</a></li>
-    <li><a href="seniority-paradox.html">Blog</a></li>
+    <li><a href="seniority-paradox.html" class="active" aria-current="page">Blog</a></li>
       <li><a href="resume.html">Resume</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
The `.top-nav a.active` style existed in the stylesheet but was never
applied — no page marked its own link active, leaving users with no
visual or semantic cue about where they are in the site.

Adds `class="active"` and `aria-current="page"` to the correct nav
link on index.htm, about.htm, seniority-paradox.html, and resume.html,
satisfying WCAG 2.4.8 (Location) and making the amber highlight actually
appear for sighted users.

https://claude.ai/code/session_013h2GxJn99gra5SVhjyiDX4